### PR TITLE
Implement authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags 2.4.0",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,6 +421,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -602,6 +659,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3852614a3bd9ca9804678ba6be5e3b8ce76dfc902cae004e3e0c44051b6e88db"
 
 [[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -645,6 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.48.0",
 ]
@@ -743,6 +811,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,11 +889,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
 ]
 
 [[package]]
@@ -925,6 +1042,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1124,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1161,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"
@@ -1060,9 +1219,29 @@ checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1156,6 +1335,8 @@ dependencies = [
  "bytes",
  "clap",
  "clap_complete",
+ "crossterm",
+ "dirs",
  "humansize",
  "indicatif",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,6 @@ dependencies = [
  "dirs",
  "humansize",
  "indicatif",
- "log",
  "reqwest",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ anyhow = "1.0.75"
 bytes = "1.4.0"
 clap = { version = "4.4.2", features = ["derive"] }
 clap_complete = "4.4.0"
+crossterm = "0.27.0"
+dirs = "5.0.1"
 humansize = "2.1.3"
 indicatif = "0.17.7"
 log = "0.4.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ crossterm = "0.27.0"
 dirs = "5.0.1"
 humansize = "2.1.3"
 indicatif = "0.17.7"
-log = "0.4.20"
 reqwest = { version = "0.11.20", default-features = false, features = ["gzip", "json",  "multipart"] }
 serde_json = "1.0.105"
 tokio = { version = "1.32.0", features = ["rt", "rt-multi-thread", "macros", "fs"] }

--- a/LICENSE
+++ b/LICENSE
@@ -174,28 +174,3 @@
       of your accepting any such warranty or additional liability.
 
    END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::fs::File;
 use std::io::Write;
 use std::{env, io};

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -1,3 +1,17 @@
+# Copyright 2023 Turing Machines
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/bin/bash
 set -x
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -58,13 +58,13 @@ pub enum Commands {
     Info,
 }
 
-#[derive(ValueEnum, Clone, PartialEq)]
+#[derive(ValueEnum, Clone, PartialEq, Eq)]
 pub enum GetSet {
     Get,
     Set,
 }
 
-#[derive(ValueEnum, Clone, PartialEq)]
+#[derive(ValueEnum, Clone, PartialEq, Eq)]
 pub enum ModeCmd {
     /// Clear any advanced mode
     Normal,
@@ -76,7 +76,7 @@ pub enum ModeCmd {
     Recovery,
 }
 
-#[derive(ValueEnum, Clone, PartialEq)]
+#[derive(ValueEnum, Clone, PartialEq, Eq)]
 pub enum UsbCmd {
     /// Configure the specified node as USB device. The `BMC` itself or USB-A
     /// port is USB host
@@ -87,7 +87,7 @@ pub enum UsbCmd {
     Status,
 }
 
-#[derive(ValueEnum, Clone, PartialEq)]
+#[derive(ValueEnum, Clone, PartialEq, Eq)]
 pub enum PowerCmd {
     On,
     Off,
@@ -95,7 +95,7 @@ pub enum PowerCmd {
     Get,
 }
 
-#[derive(ValueEnum, Clone, Copy, PartialEq)]
+#[derive(ValueEnum, Clone, Copy, PartialEq, Eq)]
 pub enum ApiVersion {
     V1,
     V1_1,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use clap::{builder::NonEmptyStringValueParser, Args, Parser, Subcommand, ValueEnum};
 use std::path::PathBuf;
 

--- a/src/legacy_handler.rs
+++ b/src/legacy_handler.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use crate::cli::{
     AdvancedArgs, ApiVersion, Commands, EthArgs, FirmwareArgs, GetSet, PowerArgs, PowerCmd,
     UartArgs, UsbArgs,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 mod cli;
 mod legacy_handler;
 mod prompt;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod cli;
 mod legacy_handler;
+mod request;
+
 use crate::legacy_handler::LegacyHandler;
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,8 +45,7 @@ async fn execute_cli_command(cli: &Cli) -> anyhow::Result<()> {
     let host = url::Host::parse(cli.host.as_ref().expect("host has a default set"))
         .map_err(|_| anyhow::anyhow!("please enter a valid hostname"))?;
 
-    LegacyHandler::new(host.to_string(), cli.json, cli.api_version.unwrap())
-        .await?
+    LegacyHandler::new(host.to_string(), cli.json, cli.api_version.unwrap())?
         .handle_cmd(command)
         .await
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod cli;
 mod legacy_handler;
+mod prompt;
 mod request;
 
 use crate::legacy_handler::LegacyHandler;

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,0 +1,146 @@
+use std::io::{stdout, Write};
+
+use anyhow::{bail, Result};
+use crossterm::cursor::MoveToColumn;
+use crossterm::event::{self, Event, KeyCode, KeyModifiers};
+use crossterm::style::Print;
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode, Clear, ClearType};
+use crossterm::{execute, queue};
+
+struct Prompt {
+    msg: &'static str,
+    password: bool,
+    input: String,
+    cursor_idx: usize,
+}
+
+impl Prompt {
+    fn new(msg: &'static str, password: bool) -> Self {
+        Self {
+            msg,
+            password,
+            input: String::new(),
+            cursor_idx: 0,
+        }
+    }
+
+    fn read(&mut self) -> Result<String> {
+        enable_raw_mode()?;
+
+        let res = self.read_loop();
+
+        disable_raw_mode()?;
+
+        match res {
+            Ok(()) => Ok(self.input.clone()),
+            Err(e) => bail!("failed to get terminal event: {e}"),
+        }
+    }
+
+    fn read_loop(&mut self) -> Result<()> {
+        execute!(stdout(), event::EnableBracketedPaste)?;
+
+        loop {
+            self.print()?;
+
+            let cont = match event::read()? {
+                Event::Key(key) => self.handle_key(key)?,
+                Event::Paste(text) => self.handle_paste(&text),
+                _ => true,
+            };
+
+            if !cont {
+                break;
+            }
+        }
+
+        execute!(stdout(), event::DisableBracketedPaste)?;
+
+        Ok(())
+    }
+
+    fn print(&self) -> Result<()> {
+        queue!(
+            stdout(),
+            MoveToColumn(0),
+            Clear(ClearType::CurrentLine),
+            Print(format!("{}: ", self.msg)),
+        )?;
+
+        if !self.password {
+            let column = self.msg.len() + self.cursor_idx + 2;
+            let column = u16::try_from(column).unwrap_or(0);
+
+            queue!(stdout(), Print(&self.input), MoveToColumn(column))?;
+        }
+
+        stdout().flush()?;
+
+        Ok(())
+    }
+
+    fn handle_key(&mut self, key: event::KeyEvent) -> Result<bool> {
+        let interrupt = key.modifiers == KeyModifiers::CONTROL && key.code == KeyCode::Char('c');
+
+        if interrupt || key.code == KeyCode::Enter {
+            execute!(stdout(), Print("\n\r"))?;
+            return Ok(false);
+        }
+
+        match key.code {
+            KeyCode::Char(c) => {
+                self.input.insert(self.cursor_idx, c);
+                self.cursor_idx += 1;
+            }
+            KeyCode::Delete => {
+                if !self.input.is_empty() {
+                    self.delete();
+                }
+            }
+            KeyCode::Backspace => {
+                if !self.input.is_empty() {
+                    self.left();
+                    self.delete();
+                }
+            }
+            KeyCode::Left => self.left(),
+            KeyCode::Right => {
+                if self.cursor_idx < self.input.len() - 1 {
+                    self.cursor_idx += 1;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(true)
+    }
+
+    fn left(&mut self) {
+        if self.cursor_idx > 0 {
+            self.cursor_idx -= 1;
+        }
+    }
+
+    fn delete(&mut self) {
+        if self.cursor_idx < self.input.len() {
+            self.input.remove(self.cursor_idx);
+        }
+    }
+
+    fn handle_paste(&mut self, text: &str) -> bool {
+        if text.chars().all(|c| c != '\n') {
+            self.input.push_str(text);
+            self.cursor_idx += text.len();
+        }
+
+        true
+    }
+}
+
+pub fn simple(msg: &'static str) -> Result<String> {
+    Prompt::new(msg, false).read()
+}
+
+pub fn password(msg: &'static str) -> Result<String> {
+    Prompt::new(msg, true).read()
+}

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::{stdout, Write};
 
 use anyhow::{bail, Result};

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,0 +1,62 @@
+//! Wrapper for `reqwest::Request` that asks for authentication if needed.
+
+use anyhow::{Context, Result};
+use reqwest::{Client, Method, Response};
+use url::Url;
+
+use crate::cli::ApiVersion;
+
+pub struct Request {
+    inner: reqwest::Request,
+}
+
+impl Request {
+    pub fn new(host: String, ver: ApiVersion) -> Result<Self> {
+        Self::construct_request(host, ver, Method::GET)
+    }
+
+    pub fn new_post(host: String, ver: ApiVersion) -> Result<Self> {
+        Self::construct_request(host, ver, Method::POST)
+    }
+
+    fn construct_request(host: String, ver: ApiVersion, method: reqwest::Method) -> Result<Self> {
+        let url = url_from_host(host, ver.scheme())?;
+        let inner = reqwest::Request::new(method, url);
+
+        Ok(Self { inner })
+    }
+
+    pub async fn send(self, client: &Client) -> Result<Response> {
+        client
+            .execute(self.inner)
+            .await
+            .context("HTTP request error")
+    }
+
+    pub fn url(&self) -> &Url {
+        self.inner.url()
+    }
+
+    pub fn url_mut(&mut self) -> &mut Url {
+        self.inner.url_mut()
+    }
+
+    pub fn as_mut(&mut self) -> &mut reqwest::Request {
+        &mut self.inner
+    }
+
+    pub fn clone(&self) -> Self {
+        let inner = self
+            .inner
+            .try_clone()
+            .expect("request cannot be cloned: body is a stream");
+
+        Self { inner }
+    }
+}
+
+fn url_from_host(host: String, scheme: &str) -> Result<Url> {
+    let mut url = Url::parse(&format!("{}://{}", scheme, host))?;
+    url.set_path("api/bmc");
+    Ok(url)
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,12 +1,18 @@
 //! Wrapper for `reqwest::Request` that asks for authentication if needed.
 
-use anyhow::{Context, Result};
-use reqwest::{Client, Method, Response};
+use std::io::Write;
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+use reqwest::{header, Client, Method, Response, StatusCode};
 use url::Url;
 
 use crate::cli::ApiVersion;
+use crate::prompt;
 
 pub struct Request {
+    host: String,
+    ver: ApiVersion,
     inner: reqwest::Request,
 }
 
@@ -20,17 +26,45 @@ impl Request {
     }
 
     fn construct_request(host: String, ver: ApiVersion, method: reqwest::Method) -> Result<Self> {
-        let url = url_from_host(host, ver.scheme())?;
+        let url = url_from_host(&host, ver.scheme())?;
         let inner = reqwest::Request::new(method, url);
 
-        Ok(Self { inner })
+        Ok(Self { host, ver, inner })
     }
 
-    pub async fn send(self, client: &Client) -> Result<Response> {
-        client
-            .execute(self.inner)
-            .await
-            .context("HTTP request error")
+    pub async fn send(mut self, client: &Client) -> Result<Response> {
+        self.add_auth_token(client, true).await?;
+
+        let resp = loop {
+            let req = self.clone().inner;
+            let resp = client.execute(req).await.context("HTTP request error")?;
+
+            if resp.status() == StatusCode::UNAUTHORIZED {
+                println!("Invalid token");
+                self.add_auth_token(client, false).await?;
+            } else {
+                break resp;
+            }
+        };
+
+        Ok(resp)
+    }
+
+    async fn add_auth_token(&mut self, client: &Client, use_cache: bool) -> Result<()> {
+        let token = if use_cache {
+            get_bearer_token(&self.host, self.ver, client).await?
+        } else {
+            request_token(&self.host, self.ver, client).await?
+        };
+
+        let header = format!("Bearer {}", token);
+
+        self.inner.headers_mut().insert(
+            header::AUTHORIZATION,
+            header.parse().context("convert to header value")?,
+        );
+
+        Ok(())
     }
 
     pub fn url(&self) -> &Url {
@@ -51,12 +85,97 @@ impl Request {
             .try_clone()
             .expect("request cannot be cloned: body is a stream");
 
-        Self { inner }
+        Self {
+            host: self.host.clone(),
+            ver: self.ver,
+            inner,
+        }
     }
 }
 
-fn url_from_host(host: String, scheme: &str) -> Result<Url> {
+fn url_from_host(host: &str, scheme: &str) -> Result<Url> {
     let mut url = Url::parse(&format!("{}://{}", scheme, host))?;
     url.set_path("api/bmc");
     Ok(url)
+}
+
+async fn get_bearer_token(host: &str, ver: ApiVersion, client: &Client) -> Result<String> {
+    if let Some(token) = get_cached_token() {
+        return Ok(token);
+    }
+
+    request_token(host, ver, client).await
+}
+
+fn get_cached_token() -> Option<String> {
+    let path = get_cache_file_location();
+    let file = std::fs::read_to_string(path);
+
+    file.ok()
+}
+
+fn get_cache_file_location() -> PathBuf {
+    let default = PathBuf::from(".");
+    let mut path = dirs::cache_dir().unwrap_or(default);
+
+    path.push("tpi_token");
+
+    path
+}
+
+async fn request_token(host: &str, ver: ApiVersion, client: &Client) -> Result<String> {
+    let mut auth_url = url_from_host(host, ver.scheme())?;
+
+    auth_url
+        .path_segments_mut()
+        .expect("URL cannot be a base")
+        .push("authenticate");
+
+    let username = prompt::simple("User")?;
+    let password = prompt::password("Password")?;
+
+    let body = serde_json::json!({
+        "username": username,
+        "password": password
+    });
+
+    let resp = client.post(auth_url).json(&body).send().await?;
+
+    match resp.status() {
+        StatusCode::OK => {
+            let json = resp.json::<serde_json::Value>().await?;
+            let token = get_param(&json, "id");
+
+            if let Err(e) = cache_token(&token) {
+                let path = get_cache_file_location();
+                println!("Warning: failed to write to cache file {:?}: {}", path, e);
+            }
+
+            Ok(token)
+        }
+        StatusCode::FORBIDDEN => bail!("Incorrect credentials"),
+        x => bail!("Unexpected status code {x}"),
+    }
+}
+
+fn get_param(results: &serde_json::Value, key: &str) -> String {
+    results
+        .get(key)
+        .unwrap_or_else(|| panic!("API error: Expected `{key}` attribute"))
+        .as_str()
+        .unwrap_or_else(|| panic!("API error: `{key}` value is not a string"))
+        .to_owned()
+}
+
+fn cache_token(token: &str) -> Result<()> {
+    let path = get_cache_file_location();
+
+    std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)?
+        .write_all(token.as_bytes())?;
+
+    Ok(())
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 Turing Machines
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 //! Wrapper for `reqwest::Request` that asks for authentication if needed.
 
 use std::io::Write;


### PR DESCRIPTION
This implements authentication based on bearer tokens, using a wrapper struct over `reqwest::Request`. In additional commits, address clippy and lack of license headers.

Fixes #2