### PR TITLE
cli: change `eth` command argument from bool to enum

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,6 +132,11 @@ pub enum PowerCmd {
     Status,
 }
 
+#[derive(ValueEnum, Clone, PartialEq, Eq)]
+pub enum EthCmd {
+    Reset,
+}
+
 #[derive(ValueEnum, Clone, Copy, PartialEq, Eq)]
 pub enum ApiVersion {
     V1,
@@ -149,9 +154,8 @@ impl ApiVersion {
 
 #[derive(Args, Clone)]
 pub struct EthArgs {
-    /// Reset Ethernet switch
-    #[arg(short, long)]
-    pub reset: bool,
+    /// Specify command
+    pub cmd: EthCmd,
 }
 
 #[derive(Args)]

--- a/src/legacy_handler.rs
+++ b/src/legacy_handler.rs
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 use crate::cli::{
-    AdvancedArgs, ApiVersion, Cli, Commands, EthArgs, FirmwareArgs, GetSet, PowerArgs, PowerCmd,
-    UartArgs, UsbArgs,
+    AdvancedArgs, ApiVersion, Cli, Commands, EthArgs, EthCmd, FirmwareArgs, GetSet, PowerArgs,
+    PowerCmd, UartArgs, UsbArgs,
 };
 use crate::cli::{FlashArgs, UsbCmd};
 use crate::request::Request;
@@ -182,15 +182,15 @@ impl LegacyHandler {
     }
 
     fn handle_eth(&mut self, args: &EthArgs) -> anyhow::Result<()> {
-        if args.reset {
-            self.request
-                .url_mut()
-                .query_pairs_mut()
-                .append_pair("opt", "set")
-                .append_pair("type", "network")
-                .append_pair("cmd", "reset");
-        } else {
-            bail!("eth subcommand called without any actions");
+        match args.cmd {
+            EthCmd::Reset => {
+                self.request
+                    .url_mut()
+                    .query_pairs_mut()
+                    .append_pair("opt", "set")
+                    .append_pair("type", "network")
+                    .append_pair("cmd", "reset");
+            }
         }
 
         self.response_printer = Some(result_printer);


### PR DESCRIPTION
This changes interface from

    tpi eth -r / tpi eth --reset

where not providing a boolean argument is invalid, to

    tpi eth reset