### PR TITLE
prompt: fix failure on powershell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,11 +246,11 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.27.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+checksum = "ab9f7409c70a38a56216480fba371ee460207dd8926ccf5b4160591759559170"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 1.3.2",
  "crossterm_winapi",
  "libc",
  "mio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1.0.75"
 bytes = "1.5.0"
 clap = { version = "4.4.7", features = ["derive", "wrap_help"] }
 clap_complete = "4.4.4"
-crossterm = "0.27.0"
+crossterm = "=0.24.0"
 dirs = "5.0.1"
 indicatif = { version = "0.17.7", features = ["tokio"] }
 platform-info = "2.0.2"

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -52,14 +52,11 @@ impl Prompt {
     }
 
     fn read_loop(&mut self) -> Result<()> {
-        execute!(stdout(), event::EnableBracketedPaste)?;
-
         loop {
             self.print()?;
 
             let cont = match event::read()? {
                 Event::Key(key) => self.handle_key(key)?,
-                Event::Paste(text) => self.handle_paste(&text),
                 _ => true,
             };
 
@@ -67,8 +64,6 @@ impl Prompt {
                 break;
             }
         }
-
-        execute!(stdout(), event::DisableBracketedPaste)?;
 
         Ok(())
     }
@@ -139,15 +134,6 @@ impl Prompt {
         if self.cursor_idx < self.input.len() {
             self.input.remove(self.cursor_idx);
         }
-    }
-
-    fn handle_paste(&mut self, text: &str) -> bool {
-        if text.chars().all(|c| c != '\n') {
-            self.input.push_str(text);
-            self.cursor_idx += text.len();
-        }
-
-        true
     }
 }
 


### PR DESCRIPTION
Changes to crossterm in 0.23..0.25 altered key handling on Windows such that identical code would break by receiving an extra Enter key event on startup.

To fix this, downgrade the dependency which, unfortunately, removes bracketed paste support introduced in 0.25.