### PR TITLE
Add environment variables for global args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = [".github", "deny.toml", "scripts/ci/*"]
 [dependencies]
 anyhow = "1.0.79"
 bytes = "1.5.0"
-clap = { version = "4.4.18", features = ["derive", "wrap_help"] }
+clap = { version = "4.4.18", features = ["derive", "wrap_help", "env"] }
 clap_complete = "4.4.9"
 crossterm = "=0.24.0"
 dirs = "5.0.1"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,24 +33,24 @@ pub struct Cli {
 
     /// Specify the Turing-pi host to connect to. Note: IPv6 addresses must be wrapped in square
     /// brackets e.g. `[::1]`
-    #[arg(default_value = DEFAULT_HOST_NAME, value_parser = NonEmptyStringValueParser::new(), long, global = true)]
+    #[arg(default_value = DEFAULT_HOST_NAME, value_parser = NonEmptyStringValueParser::new(), long, global = true, env = "TPI_HOSTNAME")]
     pub host: Option<String>,
 
     /// Specify a custom port to connect to.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "TPI_PORT")]
     pub port: Option<u16>,
 
     /// Specify a user name to log in as. If unused, an interactive prompt will ask for credentials
     /// unless a cached token file is present.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "TPI_USERNAME")]
     pub user: Option<String>,
 
     /// Same as `--username`
-    #[arg(long, name = "PASS", global = true)]
+    #[arg(long, name = "PASS", global = true, env = "TPI_PASSWORD", hide_env_values = true)]
     pub password: Option<String>,
 
     /// Print results formatted as JSON
-    #[arg(long, global = true)]
+    #[arg(long, global = true, env = "TPI_OUTPUT_JSON")]
     pub json: bool,
 
     /// Force which version of the BMC API to use. Try lower the version if you are running


### PR DESCRIPTION
Adds a `TPI_HOSTNAME`, `TPI_USERNAME`, `TPI_PASSWORD` and `TPI_OUTPUT_JSON` as fallbacks for the `--host`, `--user`, `--password`, and `--json` global arguments

```shell
$ tpi --help
Official Turing-Pi2 CLI tool

Usage: tpi [OPTIONS] [COMMAND]

[..snip..]

Options:
      --host <HOST>        Specify the Turing-pi host to connect to. Note: IPv6 addresses must be wrapped in square brackets e.g. `[::1]`
                           [env: TPI_HOSTNAME=] [default: turingpi.local]
      --port <PORT>        Specify a custom port to connect to [env: TPI_PORT=]
      --user <USER>        Specify a user name to log in as. If unused, an interactive prompt will ask for credentials unless a cached token
                           file is present [env: TPI_USERNAME=]
      --password <PASS>    Same as `--username` [env: TPI_PASSWORD=]
      --json               Print results formatted as JSON [env: TPI_OUTPUT_JSON=]
```
(clap's help message gen will also include the values if they are found in the environment;

of note this can—under less than clear conditions (something termcap-y?)—cause(?) the help to get re-[flowed](https://github.com/turing-machines/tpi/assets/43136/aca0ca5c-d00d-45a1-997f-40fc1bfc9c67). If anything, its more legible that way - but in case there's anything text-parsing this output somewhere [in tests or automation] seems worth mentioning)



[why? b/c I am connecting to my cluster over tailscale (after [these](https://github.com/donaldguy/tpi-BMC-Firmware/commit/ca5c03873d02a042ee6d467973e67ba9dafb5996) modifications to the BMC firmware to make that possible) and getting tired of typing `--host turingpi.XXXX.ts.net` ; 

but also broadly I believe these should be options]

---

It is plausible that it is preferable to match the argument names, but I leaned in the direction of things that are slightly more self-documenting in the context of a `.bashrc` or `.zshenv`

---

I have mixed feelings about encouraging mediocre security practices vis-a-vis putting a secret in an environment variable (and probably directly in a file); 

The easiest alternative there would be to have a TPI_PASSWORD_CMD that one could set to e.g. `op item get "Turing Pi BMC root" --field label=password` (that or go harder on e.g. TLS client certs, etc.)