### PR TITLE
fix: info result printer

### DIFF
--- a/src/legacy_handler.rs
+++ b/src/legacy_handler.rs
@@ -686,11 +686,11 @@ fn info_printer(map: &serde_json::Value) -> anyhow::Result<()> {
         .as_object()
         .context("response parse error")?;
 
-    println!("|{:-^10}|{:-^28}|", "key", "value");
+    println!("|{:-^15}|{:-^28}|", "key", "value");
     for (key, value) in results {
-        println!(" {:<10}: {}", key, value.as_str().expect("API error"));
+        println!(" {:<15}: {}", key, value.as_str().expect("API error"));
     }
-    println!("|{:-^10}|{:-^28}|", "", "");
+    println!("|{:-^15}|{:-^28}|", "", "");
     Ok(())
 }
 


### PR DESCRIPTION
This fixes #41 the alignment of the `info` command.

Old output:

```shell
➜  TuringPI tpi info       
|---key----|-----------value------------|
 api       : 1.1
 build_version: 2024.05.1
 buildroot : "Buildroot 2024.05.1"
 buildtime : 2025-01-17 17:12:52-00:00
 ip        : Unknown
 mac       : Unknown
 version   : 2.3.4
|----------|----------------------------|
➜  TuringPI
```

After fix; new alignment:

```shell
➜  tpi git:(fix/info) ./target/debug/tpi info
|------key------|-----------value------------|
 api            : 1.1
 build_version  : 2024.05.1
 buildroot      : "Buildroot 2024.05.1"
 buildtime      : 2025-01-17 17:12:52-00:00
 ip             : Unknown
 mac            : Unknown
 version        : 2.3.4
|---------------|----------------------------|
➜  tpi git:(fix/info)
```